### PR TITLE
Fix secret deployment

### DIFF
--- a/api/.env-example
+++ b/api/.env-example
@@ -6,6 +6,4 @@ SUPABASE_KEY=""
 DEV_SUPABASE_URL=""
 DEV_SUPABASE_KEY=""
 
-.env file
-
 SECRET=""

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "shuttle-codegen"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503f3b6c11c193c593394dab348003e4c5813f186f13d9aa7a8172bd636b2458"
+checksum = "2814be527dddb99eb25b6ec03e2b9f1ba0cfa09c0c1c6a71252eb437b98a49f1"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -1775,12 +1775,14 @@ dependencies = [
 
 [[package]]
 name = "shuttle-common"
-version = "0.10.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b613601be7fc96760dcc91aae0b3a02d4130ed54384674eb0370e0c46de55c"
+checksum = "4bff54889167075a0866629bc1aa68f27f60b720638d73d98b6c736dc130ad7b"
 dependencies = [
  "chrono",
+ "headers",
  "once_cell",
+ "pin-project",
  "rustrict",
  "serde",
  "strum",
@@ -1790,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "shuttle-secrets"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d78194d634c98f98a689f3da0bf4b12bc96799a2a01a16347c06d6221950183"
+checksum = "8ca583db7b0db5bf6f478a0a7263c265eb9734d47e9128cca81b6b2ca448ffbc"
 dependencies = [
  "async-trait",
  "shuttle-service",
@@ -1801,9 +1803,9 @@ dependencies = [
 
 [[package]]
 name = "shuttle-service"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b71e368b655c6e4d2dba14f57f9a28cd1077a2a5182c773af0f3848c6a16629"
+checksum = "5ed02802808015ea2a4ae3e4a9d0192ebaefdacf212a05eae6aa65121e9f57a2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -24,8 +24,6 @@ dependencies = [
  "axum",
  "axum-login",
  "base64 0.21.0",
- "dotenv",
- "dotenv_codegen",
  "hyper",
  "jsonwebtoken",
  "once_cell",
@@ -531,35 +529,6 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
-name = "dotenv_codegen"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56966279c10e4f8ee8c22123a15ed74e7c8150b658b26c619c53f4a56eb4a8aa"
-dependencies = [
- "dotenv_codegen_implementation",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "dotenv_codegen_implementation"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e737a3522cd45f6adc19b644ce43ef53e1e9045f2d2de425c1f468abd4cf33"
-dependencies = [
- "dotenv",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "dyn-clone"
@@ -1384,12 +1353,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -8,10 +8,10 @@ publish = false
 
 [dependencies]
 postgrest = "1.0"
-shuttle-service = { version = "0.10.0", features = ["web-axum"] }
+shuttle-service = { version = "0.11.0", features = ["web-axum"] }
 axum = { version = "0.6.4", features = ["headers"] }
 sync_wrapper = "0.1.1"
-shuttle-secrets = "0.10.0"
+shuttle-secrets = "0.11.0"
 hyper = { version = "0.14.23", features = ["full"] }
 tokio = { version = "1.22.0", features = ["full"] }
 tower = "0.4.13"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -20,8 +20,6 @@ serde_json = "1.0.91"
 serde = "1.0.152"
 axum-login = "0.4.1"
 rand = "0.8.5"
-dotenv = "0.15.0"
-dotenv_codegen = "0.15.0"
 sha2 = "0.10.6"
 base64 = "0.21.0"
 reqwest = { version = "0.11.14", features = ["json"] }

--- a/api/src/models/auth.rs
+++ b/api/src/models/auth.rs
@@ -41,8 +41,12 @@ where
             .map_err(|_| ApiError::AuthenticationError)?;
 
         // Decode the user data
-        let token_data = decode::<Claims>(bearer.token(), &KEYS.decoding, &Validation::default())
-            .map_err(|_| ApiError::AuthenticationError)?;
+        let token_data = decode::<Claims>(
+            bearer.token(),
+            &KEYS.get().unwrap().decoding,
+            &Validation::default(),
+        )
+        .map_err(|_| ApiError::AuthenticationError)?;
 
         Ok(token_data.claims)
     }


### PR DESCRIPTION
Resolves #16 

---

This PR
- Updates shuttle to 0.11.0.
- Removes dotenv and uses shuttle_secrets for the JWT key.